### PR TITLE
Add jq flavored version of jsons-print-path

### DIFF
--- a/json-snatcher.el
+++ b/json-snatcher.el
@@ -79,6 +79,7 @@
 (defvar jsons-parsed-regions (make-hash-table :test 'equal)
   "Hashes each open buffer to the ranges in the buffer for each of the parse trees nodes.")
 (defvar jsons-curr-region () "The node ranges in the current buffer.")
+(defvar jsons-path-printer 'jsons-print-path-python "Default jsons path printer")
 (add-hook 'kill-buffer-hook 'jsons-remove-buffer)
 
 (defun jsons-consume-token ()
@@ -283,10 +284,30 @@ TODO: Remove extra comma printed after lists of object members, and lists of arr
       (jsons-print-to-buffer buffer (elt node 1)))
      (t nil))))
 
-;;;###autoload
-(defun jsons-print-path ()
-  "Print the path to the JSON value under point, and save it in the kill ring."
-  (interactive)
+(defun jsons-print-path-jq ()
+  "Print the jq path to the JSON value under point, and save it in the kill ring."
+  (let* ((path (jsons-get-path))
+         (i 0)
+         (jq_str ".")
+         key)
+    (setq path (reverse path))
+    (while (< i (length path))
+      (if (numberp (elt path i))
+          (progn
+            (setq jq_str (concat jq_str "[" (number-to-string (elt path i)) "]"))
+            (setq i (+ i 1)))
+        (progn
+          (setq key (elt path i))
+          (setq jq_str (concat jq_str (substring key 1 (- (length key) 1))))
+          (setq i (+ i 1))))
+      (when (elt path i)
+        (unless (numberp (elt path i))
+          (setq jq_str (concat jq_str ".")))))
+    (progn (kill-new jq_str)
+           (princ jq_str))))
+
+(defun jsons-print-path-python ()
+  "Print the python path to the JSON value under point, and save it in the kill ring."
   (let ((path (jsons-get-path))
         (i 0)
         (python_str ""))
@@ -301,6 +322,12 @@ TODO: Remove extra comma printed after lists of object members, and lists of arr
           (setq i (+ i 1)))))
     (progn (kill-new python_str)
            (princ python_str))))
+
+;;;###autoload
+(defun jsons-print-path ()
+  "Print the path to the JSON value under point, and save it in the kill ring."
+  (interactive)
+  (funcall jsons-path-printer))
 
 (defun jsons-put-string (buffer str)
   "Append STR to the BUFFER specified in the argument."


### PR DESCRIPTION
Add jsons-path-printer var, defaulting to the python flavor.