### PR TITLE
move add-hook kill-buffer-hook after defun

### DIFF
--- a/json-snatcher.el
+++ b/json-snatcher.el
@@ -80,7 +80,6 @@
   "Hashes each open buffer to the ranges in the buffer for each of the parse trees nodes.")
 (defvar jsons-curr-region () "The node ranges in the current buffer.")
 (defvar jsons-path-printer 'jsons-print-path-python "Default jsons path printer")
-(add-hook 'kill-buffer-hook 'jsons-remove-buffer)
 
 (defun jsons-consume-token ()
   "Return the next token in the stream."
@@ -340,6 +339,8 @@ TODO: Remove extra comma printed after lists of object members, and lists of arr
   (progn
     (remhash (current-buffer) jsons-parsed)
     (remhash (current-buffer) jsons-parsed-regions)))
+
+(add-hook 'kill-buffer-hook 'jsons-remove-buffer)
 
 (provide 'json-snatcher)
 


### PR DESCRIPTION
kill-buffer-hook as an extremely dangerous hook to add to in the even
that something fails. The fact that symbol that was added was void at
the time of binding was one of the underlying causes of this emacs bug
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=43190.

Therefore I moved the call to add-hook after the definition of
jsons-remove-buffer so that it is impossible for the symbol to be
unbound in the event that something goes wrong in between the addition
of the symbol to the hook and the binding of the symbol to a function.
Instead, if a failure occures before adding the hook, the hook will
never be added, avoiding a nasty state where kill-buffer fails, taking
down quite a bit of emacs functionality with it.