### PR TITLE
Resolve all byte compiler warnings on Emacs 29

### DIFF
--- a/json-snatcher.el
+++ b/json-snatcher.el
@@ -307,21 +307,17 @@ TODO: Remove extra comma printed after lists of object members, and lists of arr
            (princ jq_str))))
 
 (defun jsons-print-path-python ()
-  "Print the python path to the JSON value under point, and save it in the kill ring."
+  "Print the python path of the JSON value at point, and save it in the kill ring."
   (let ((path (jsons-get-path))
-        (i 0)
-        (python_str ""))
-    (setq path (reverse path))
-    (while (< i (length path))
-      (if (numberp (elt path i))
-          (progn
-            (setq python_str (concat python_str "[" (number-to-string (elt path i)) "]"))
-            (setq i (+ i 1)))
-        (progn
-          (setq python_str (concat python_str "[" (elt path i) "]"))
-          (setq i (+ i 1)))))
-    (progn (kill-new python_str)
-           (princ python_str))))
+		(python-str ""))
+	(setq python-str (concat "["
+							 ;; TODO: Is it possible to have numbers here?
+							 (if (numberp (car path))
+								 (string-to-number (pop path))
+							   (pop path))
+							 "]" python-str))
+	(kill-new python-str)
+	(princ python-str)))
 
 ;;;###autoload
 (defun jsons-print-path ()

--- a/json-snatcher.el
+++ b/json-snatcher.el
@@ -221,14 +221,15 @@ points to the index of this value in the containing array."
 
 (defun jsons-is-number (str)
   "Test to see whether STR is a valid JSON number."
-  (progn
-    (match-end 0)
-    (save-match-data
-      (if (string-match "^\\(-?\\(0\\|\\([1-9][[:digit:]]*\\)\\)\\(\\.[[:digit:]]+\\)?\\([eE][-+]?[[:digit:]]+\\)?\\)$" str)
-          (progn
-            (match-end 0)
-            t)
-        nil))))
+  (string-match-p
+   (rx bol
+	   (optional ?-)
+	   (or ?0
+		   (seq (any "1-9") (* digit)))
+	   (optional ?. (+ digit))
+	   (optional (any "eE") (optional (any "-+")) (+ digit))
+	   eol)
+   str))
 
 (defun jsons-parse ()
   "Parse the file given in file, return a list of nodes representing the file."

--- a/json-snatcher.el
+++ b/json-snatcher.el
@@ -77,9 +77,9 @@
 (defvar jsons-parsed (make-hash-table :test 'equal)
   "Hashes each open buffer to the parse tree for that buffer.")
 (defvar jsons-parsed-regions (make-hash-table :test 'equal)
-  "Hashes each open buffer to the ranges in the buffer for each of the parse trees nodes.")
+  "Hashes buffer to parse tree node ranges for parse trees nodes of the buffer.")
 (defvar jsons-curr-region () "The node ranges in the current buffer.")
-(defvar jsons-path-printer 'jsons-print-path-python "Default jsons path printer")
+(defvar jsons-path-printer 'jsons-print-path-python "Default jsons path printer.")
 
 (defun jsons-consume-token ()
   "Return the next token in the stream."
@@ -203,7 +203,7 @@ points to the index of this value in the containing array."
 
 
 (defun jsons-get-path ()
-  "Function to check whether we can grab the json path from the cursor position in the json file."
+  "Check whether we can grab the json path from point in the current buffer."
   (let ((i 0)
         (node nil))
     (setq jsons-curr-region (gethash (current-buffer) jsons-parsed-regions))
@@ -250,7 +250,8 @@ points to the index of this value in the containing array."
 
 (defun jsons-print-to-buffer (node buffer)
   "Prints the given NODE to the BUFFER specified in buffer argument.
-TODO: Remove extra comma printed after lists of object members, and lists of array members."
+TODO: Remove extra comma printed after lists of object members,
+and lists of array members."
   (let ((id (elt node 0)))
     (cond
      ((string= id "json-array")


### PR DESCRIPTION
Ended up rewriting two functions.  One of them were not using return values of match-end, the other one was mostly to make sure I understood what the function did before rewriting the docstring.